### PR TITLE
Fix bug in infrastructure-jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 aws.json
 .Rhistory
+.Rproj.user
+.RData

--- a/infrastructure-jobs/infrastructure-jobs.R
+++ b/infrastructure-jobs/infrastructure-jobs.R
@@ -23,10 +23,6 @@ series<-merge(series,state,by="state_code")
 
 # Add industry info
 industry<-read.table("http://download.bls.gov/pub/time.series/sm/sm.industry", sep="\t", header=TRUE, strip.white=TRUE)
-industry$industry_name<-NULL
-industry$industry_name<-row.names(industry)
-row.names(industry)<-NULL
-names(industry)<-c("industry_name","industry_code")
 
 series<-merge(series,industry,by="industry_code")
 

--- a/infrastructure-jobs/infrastructure-jobs.Rproj
+++ b/infrastructure-jobs/infrastructure-jobs.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX


### PR DESCRIPTION
Fixes code block so `industry` dataframe can be joined to `series` dataframe. The
previous version removed the necessary foreign keys in the `industry` dataframe. 