### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/bob-ross/cluster-paintings.py
+++ b/bob-ross/cluster-paintings.py
@@ -5,6 +5,7 @@ By Walter Hickey <walter.hickey@fivethirtyeight.com>
 
 See http://fivethirtyeight.com/features/a-statistical-analysis-of-the-work-of-bob-ross/
 """
+from __future__ import print_function
 
 import numpy as np
 from scipy.cluster.vq import vq, kmeans, whiten
@@ -35,7 +36,7 @@ def main():
     whitened = whiten(matrix)
     output = kmeans(whitened, 10)
 
-    print "episode", "distance", "cluster"
+    print("episode", "distance", "cluster")
 
     # determine distance between each of 403 vectors and each centroid, find closest neighbor
     for i, v in enumerate(whitened):
@@ -53,7 +54,7 @@ def main():
             if dist_x < closest_match[0]:
                 closest_match = (dist_x, x)
 
-        print i+1, closest_match[0], closest_match[1]
+        print(i+1, closest_match[0], closest_match[1])
 
 if __name__ == "__main__":
     main()

--- a/classic-rock/compiling_radio.py
+++ b/classic-rock/compiling_radio.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 def hr_pull(x,y):
 	iteration = 0
 	callsign = x[2]
@@ -106,5 +107,5 @@ dy_pull(cb2,6)
 dy_pull(cb3,6)
 	
 	
-print "Done"
+print("Done")
 	

--- a/repeated-phrases-gop/robopol2.py
+++ b/repeated-phrases-gop/robopol2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import random
 import numpy
 import math
@@ -196,9 +197,9 @@ def main():
     
     # print the top ngrams sorted by tfidf
     for candidate in range(len(candidates)):
-        print candidates[candidate]
+        print(candidates[candidate])
         for ngram in top_ngrams_for_candidate(tfidf_dicts, candidate, 400):
-            print ngram
+            print(ngram)
     
     
     


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.